### PR TITLE
Add config to run black and flake8 for code formatting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,15 @@ python:
   - 3.6
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install:
+  - pip install pytest innerscope scipy numpy flake8 black
 
-
-install: 
-  - pip install pytest innerscope scipy numpy 
-
-  
 # Command to run tests, e.g. python setup.py test
-script: 
+script:
   - pip install -e .
   - pytest
+  # - black pypowerup --check --diff  # TODO: uncomment
+  # - flake8  # TODO: uncomment
 
 notifications:
   email: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 100
+exclude =
+    pypowerup/__init__.py,
+    pypowerup/tests/,
+    build/,
+    docs/
+ignore =
+    W503,   # line break before binary operator
+    F821,   # undefined name


### PR DESCRIPTION
This did not run `black pypowerup` command.
Also, formatting can be tested by uncommenting the lines I added to .travis.yml

I configured both `black` and `flake8` to allow line lengths of 100.